### PR TITLE
Change the URL for the backend API to point to the Render cloud service

### DIFF
--- a/src/app/apolloClient.tsx
+++ b/src/app/apolloClient.tsx
@@ -3,7 +3,7 @@
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
 
 const client = new ApolloClient({
-  uri: "http://localhost:8082/graphql",
+  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
   cache: new InMemoryCache(),
 });
 

--- a/src/components/ApolloWrapper.tsx
+++ b/src/components/ApolloWrapper.tsx
@@ -3,7 +3,7 @@
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
 
 const client = new ApolloClient({
-  uri: "http://198.71.55.151/graphql",
+  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
   // uri: "http://localhost:8082/graphql",
   cache: new InMemoryCache(),
 });

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -2,7 +2,7 @@ import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
 
 const client = new ApolloClient({
   link: new HttpLink({
-    uri: "http://localhost:8082/graphql",
+    uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
   }),
   cache: new InMemoryCache(),
 });

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -16,7 +16,7 @@ export const { getClient } = registerApolloClient(
     new ApolloClient({
       cache: new InMemoryCache(),
       link: new HttpLink({
-        uri: "http://localhost:8082/graphql",
+        uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
       }),
     }),
 );


### PR DESCRIPTION
I'm not sure why we have this URL in so many places.