### PR TITLE
Add API key header for graphql API requests

### DIFF
--- a/src/app/apolloClient.tsx
+++ b/src/app/apolloClient.tsx
@@ -1,10 +1,27 @@
 "use client";
 
-import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
+import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from "@apollo/client";
+import { setContext } from '@apollo/client/link/context';
+
+const httpLink = createHttpLink({
+  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
+});
+
+const authLink = setContext((_, { headers }) => {
+  // Get the API key from an environment variable
+  const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+
+  return {
+    headers: {
+      ...headers,
+      'X-Api-Key': apiKey,
+    }
+  };
+});
 
 const client = new ApolloClient({
-  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
   cache: new InMemoryCache(),
+  link: authLink.concat(httpLink),
 });
 
 export default function ApolloWrapper({

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -1,10 +1,25 @@
-import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
+import { ApolloClient, InMemoryCache, createHttpLink } from "@apollo/client";
+import { setContext } from '@apollo/client/link/context';
+
+const httpLink = createHttpLink({
+  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
+});
+
+const authLink = setContext((_, { headers }) => {
+  // Get the API key from an environment variable
+  const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+
+  return {
+    headers: {
+      ...headers,
+      'X-Api-Key': apiKey,
+    }
+  };
+});
 
 const client = new ApolloClient({
-  link: new HttpLink({
-    uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
-  }),
   cache: new InMemoryCache(),
+  link: authLink.concat(httpLink),
 });
 
 export default client;


### PR DESCRIPTION
Once the backend server is updated, you will need this.

In your local environment, define a file named .env.local

Add a line like this to your file with the appropriate api key value

NEXT_PUBLIC_API_KEY=<thesecretapikey>
