### PR TITLE
Hide API key

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,8 +2,9 @@
 const nextConfig = {
   env: {
     RESEND_API_KEY: "re_ZacMr3bG_MZCB3tg788UrUieq3XgMh3hX",
-    NEXT_PUBLIC_API_KEY: "NmrbgWVGLVfcA3pnGAYGTOeLY4OvanBaFOl9VRiP5ys",
+    API_KEY: process.env.API_KEY,
     //when the server is run locally, I believe this key is "whatever"
+    API_URL: process.env.API_URL,
   },
 };
 

--- a/src/app/api/graphql/route.tsx
+++ b/src/app/api/graphql/route.tsx
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const response = await fetch(process.env.API_URL as string, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Api-Key': process.env.API_KEY as string,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error in GraphQL proxy:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  return NextResponse.json(
+    { error: 'Method not allowed' },
+    { status: 405 }
+  );
+}

--- a/src/app/apolloClient.tsx
+++ b/src/app/apolloClient.tsx
@@ -4,24 +4,12 @@ import { ApolloClient, InMemoryCache, ApolloProvider, createHttpLink } from "@ap
 import { setContext } from '@apollo/client/link/context';
 
 const httpLink = createHttpLink({
-  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
-});
-
-const authLink = setContext((_, { headers }) => {
-  // Get the API key from an environment variable
-  const apiKey = process.env.NEXT_PUBLIC_API_KEY;
-
-  return {
-    headers: {
-      ...headers,
-      'X-Api-Key': apiKey,
-    }
-  };
+  uri: "/api/graphql"
 });
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: authLink.concat(httpLink),
+  link: httpLink,
 });
 
 export default function ApolloWrapper({

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -2,24 +2,12 @@ import { ApolloClient, InMemoryCache, createHttpLink } from "@apollo/client";
 import { setContext } from '@apollo/client/link/context';
 
 const httpLink = createHttpLink({
-  uri: "https://straightforward-job-site-backend-obsy.onrender.com/graphql",
-});
-
-const authLink = setContext((_, { headers }) => {
-  // Get the API key from an environment variable
-  const apiKey = process.env.NEXT_PUBLIC_API_KEY;
-
-  return {
-    headers: {
-      ...headers,
-      'X-Api-Key': apiKey,
-    }
-  };
+  uri: "/api/graphql"
 });
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: authLink.concat(httpLink),
+  link: httpLink,
 });
 
 export default client;


### PR DESCRIPTION
This is moving the api key from the client to the server side.
Also make the api url be configurable.
When running local these need to be set in .env.local
Otherwise they will come from Vercel environment settings